### PR TITLE
Add read the docs system using mkdocs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 
 # IDE
 .vscode/
+
+# Documention
+site/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ $ cmake --build .
 
 GameMesh has the most extensive and thorough [documentation](https://game-mesh.readthedocs.io/en/latest/), making it a breeze to get started with the framework.
 
+#### Built-in server
+
+A quick documention to install [mkdocs](https://www.mkdocs.org/#installation).
+
+```shell
+$ mkdocs serve
+```
+
+Open up `http://127.0.0.1:8000/` in your browser, and you'll see the document home page being displayed.
+
 ## Requirements
 
 **Required:**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Game Mesh [![build](https://github.com/tweether/game-mesh/workflows/build/badge.svg)](https://github.com/tweether/game-mesh/actions?query=workflow%3Abuild) [![Build Status](https://travis-ci.com/tweether/game-mesh.svg?branch=master)](https://travis-ci.com/tweether/game-mesh) [![codecov](https://codecov.io/gh/tweether/game-mesh/branch/master/graph/badge.svg)](https://codecov.io/gh/tweether/game-mesh) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/14e8cb11e6cb4b8897e8939cce256dac)](https://www.codacy.com/gh/tweether/game-mesh?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tweether/game-mesh&amp;utm_campaign=Badge_Grade)
+# Game Mesh [![build](https://github.com/tweether/game-mesh/workflows/build/badge.svg)](https://github.com/tweether/game-mesh/actions?query=workflow%3Abuild) [![Build Status](https://travis-ci.com/tweether/game-mesh.svg?branch=master)](https://travis-ci.com/tweether/game-mesh) [![codecov](https://codecov.io/gh/tweether/game-mesh/branch/master/graph/badge.svg)](https://codecov.io/gh/tweether/game-mesh) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/14e8cb11e6cb4b8897e8939cce256dac)](https://www.codacy.com/gh/tweether/game-mesh?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tweether/game-mesh&amp;utm_campaign=Badge_Grade) [![Documentation Status](https://readthedocs.org/projects/game-mesh/badge/?version=latest)](https://game-mesh.readthedocs.io/en/latest/?badge=latest)
 
 !!! This project is in a rapid iteration period, please do not use. !!!
 
@@ -14,6 +14,10 @@ $ mkdir build && cd build
 $ cmake ..
 $ cmake --build .
 ```
+
+## Learning
+
+GameMesh has the most extensive and thorough [documentation](https://game-mesh.readthedocs.io/en/latest/), making it a breeze to get started with the framework.
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,17 @@
-# Welcome to MkDocs
+# GameMesh
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+A fast, scalable, distributed, testable game server framework.
 
-## Commands
+## Requirements
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+**Required:**
 
-## Project layout
+- [conan](https://conan.io/) (>= 1.0)
+- [cmake](https://cmake.org/) (>= 3.8)
+- [gcc](https://gcc.gnu.org/) (>= 7.5)
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+**Options:**
+
+- [cpplint](https://github.com/cpplint/cpplint)
+- [cppcheck](http://cppcheck.sourceforge.net/)
+- [lcov](http://ltp.sourceforge.net/coverage/lcov.php)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,3 @@
-site_name: Game Mesh Documention
+site_name: GameMesh Documention
 theme: readthedocs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: Game Mesh Documention
+theme: readthedocs
+

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,6 @@
+version: 2
+
+mkdocs:
+  configuration: mkdocs.yml
+
+formats: all


### PR DESCRIPTION
Added document hosting based on [readthedocs](https://readthedocs.org/) for the project.

We use [mkdocs](https://github.com/mkdocs/mkdocs) as the basic document building system.

The documents are stored in the `docs/` folder and are saved format of `markdown`.  The modification of the document will be submitted to readthedocs via webhook, and will be automatically built and updated.

The following is the public access address:

https://game-mesh.readthedocs.io/en/latest/

Building documents locally is very convenient, through:

```shell
$ mkdocs serve
```

There is a flaw in the construction of `mkdocs`, which will prevent localization (may improve in the future)

https://docs.readthedocs.io/en/stable/localization.html

Using [Sphinx](https://github.com/sphinx-doc/sphinx) will solve this problem, but considering the learning complexity, we did not choose
